### PR TITLE
Ajustados textos para tamanhos de fonte diferentes

### DIFF
--- a/lib/Screens/InterventionListing/Widgets/body.dart
+++ b/lib/Screens/InterventionListing/Widgets/body.dart
@@ -128,8 +128,8 @@ class IntervCard extends StatelessWidget {
                   child: SizedBox(
                     height: 106,
 
-                    ///our image take 100 width, so we set our total width -100
-                    width: size.width - 100,
+                    ///our image take 116 width, so we set our total width -116
+                    width: size.width - 116,
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: <Widget>[

--- a/lib/Screens/InterventionListing/intervention_list.dart
+++ b/lib/Screens/InterventionListing/intervention_list.dart
@@ -18,7 +18,7 @@ class GroupListScreen extends StatelessWidget {
             color: Colors.white,
             onPressed: () => {Navigator.pop(context)},
           ),
-          title: Text(group)),
+          title: FittedBox(child: Text(group))),
       body: Body(group),
     );
   }

--- a/lib/Screens/Questionarie/Widgets/app_body_widget.dart
+++ b/lib/Screens/Questionarie/Widgets/app_body_widget.dart
@@ -25,7 +25,7 @@ class QuizCard extends StatelessWidget {
     var minutesToExpire = difference.inMinutes;
 
     String expirationText;
-    
+
     // Calcula a constroi o texto para informar o usuário do período restante em que a escala/questionário estará disponível
     if (daysToExpire > 0) {
       expirationText = 'Expira em $daysToExpire dia(s)';
@@ -71,9 +71,11 @@ class QuizCard extends StatelessWidget {
                 children: [
                   Expanded(
                       flex: 1,
-                      child: Text(
-                        completed,
-                        style: AppTextStyles.body11,
+                      child: FittedBox(
+                        child: Text(
+                          completed,
+                          style: AppTextStyles.body11,
+                        ),
                       )),
                   Expanded(
                       flex: 1,

--- a/lib/Screens/Questionarie/quests_screen.dart
+++ b/lib/Screens/Questionarie/quests_screen.dart
@@ -117,11 +117,13 @@ class _QuestsScreenState extends State<QuestsScreen> {
                         tabs: [
                           new Container(
                             height: 50.0,
-                            child: new Tab(text: 'Nessa semana'),
+                            child:
+                                FittedBox(child: new Tab(text: 'Nessa semana')),
                           ),
                           new Container(
                             height: 50.0,
-                            child: new Tab(text: 'Respondidos'),
+                            child:
+                                FittedBox(child: new Tab(text: 'Respondidos')),
                           ),
                         ],
                       )))),

--- a/lib/Screens/Reading/reading_screen.dart
+++ b/lib/Screens/Reading/reading_screen.dart
@@ -74,7 +74,10 @@ class ReadingScreen extends StatelessWidget {
           color: Colors.white,
           onPressed: () => {Navigator.pop(context)},
         ),
-        title: Text(title),
+        title: FittedBox(
+          fit: BoxFit.contain,
+          child: Text(title),
+        ),
         actions: [
           TextButton(
             style: TextButton.styleFrom(

--- a/lib/Screens/SleepDiary/sleep_diary.dart
+++ b/lib/Screens/SleepDiary/sleep_diary.dart
@@ -56,7 +56,7 @@ class _SleepPageState extends State<SleepPage> {
       databaseMethods.addRespostaQuestionarioSono(
           FirebaseAuth.instance.currentUser!.uid, messageMap, data);
       setState(() {
-        //dataIgual = true;
+        dataIgual = true;
       });
     }
   }
@@ -76,11 +76,11 @@ class _SleepPageState extends State<SleepPage> {
       value.docs.forEach((element) {
         if (element.id == data) {
           print("${element.id} é = a ${data}");
-          //dataIgual = true;
+          dataIgual = true;
         }
       });
       setState(() {
-        //dataIgual = dataIgual;
+        dataIgual = dataIgual;
         _loading = false;
       });
     });

--- a/lib/Screens/SleepDiary/sleep_diary.dart
+++ b/lib/Screens/SleepDiary/sleep_diary.dart
@@ -4,6 +4,7 @@ import 'package:app_mental/constants.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:auto_size_text/auto_size_text.dart';
 
 class SleepPage extends StatefulWidget {
   @override
@@ -55,7 +56,7 @@ class _SleepPageState extends State<SleepPage> {
       databaseMethods.addRespostaQuestionarioSono(
           FirebaseAuth.instance.currentUser!.uid, messageMap, data);
       setState(() {
-        dataIgual = true;
+        //dataIgual = true;
       });
     }
   }
@@ -75,11 +76,11 @@ class _SleepPageState extends State<SleepPage> {
       value.docs.forEach((element) {
         if (element.id == data) {
           print("${element.id} é = a ${data}");
-          dataIgual = true;
+          //dataIgual = true;
         }
       });
       setState(() {
-        dataIgual = dataIgual;
+        //dataIgual = dataIgual;
         _loading = false;
       });
     });
@@ -87,15 +88,15 @@ class _SleepPageState extends State<SleepPage> {
 
   Widget _buildQuest1() {
     return Container(
-      height: 50,
+      height: 80,
       margin: EdgeInsets.symmetric(vertical: 10.0),
       child: ListView(
         scrollDirection: Axis.horizontal,
         children: [
           Container(
             alignment: Alignment.center,
-            width: 200,
-            child: Text(
+            width: MediaQuery.of(context).size.width * .50,
+            child: AutoSizeText(
               "Que horas você foi para a cama?",
               style: TextStyle(fontSize: 16),
             ),
@@ -140,15 +141,15 @@ class _SleepPageState extends State<SleepPage> {
 
   Widget _buildQuest2() {
     return Container(
-      height: 50,
+      height: 80,
       margin: EdgeInsets.symmetric(vertical: 10.0),
       child: ListView(
         scrollDirection: Axis.horizontal,
         children: [
           Container(
             alignment: Alignment.center,
-            width: 200,
-            child: Text(
+            width: MediaQuery.of(context).size.width * .50,
+            child: AutoSizeText(
               "A que horas você tentou dormir?",
               style: TextStyle(fontSize: 16),
             ),
@@ -194,15 +195,15 @@ class _SleepPageState extends State<SleepPage> {
 
   Widget _buildQuest3() {
     return Container(
-      height: 50,
+      height: 80,
       margin: EdgeInsets.symmetric(vertical: 10.0),
       child: ListView(
         scrollDirection: Axis.horizontal,
         children: [
           Container(
             alignment: Alignment.center,
-            width: 200,
-            child: Text(
+            width: MediaQuery.of(context).size.width * .50,
+            child: AutoSizeText(
               "Quanto tempo você demorou para adormecer?",
               style: TextStyle(fontSize: 16),
             ),
@@ -247,15 +248,14 @@ class _SleepPageState extends State<SleepPage> {
 
   Widget _buildQuest4() {
     return Container(
-      height: 75,
+      height: 80,
       margin: EdgeInsets.symmetric(vertical: 10.0),
       child: ListView(
         scrollDirection: Axis.horizontal,
         children: [
           Container(
-            alignment: Alignment.center,
-            width: 200,
-            child: Text(
+            width: MediaQuery.of(context).size.width * .50,
+            child: AutoSizeText(
               "Quantas vezes você acordou, sem contar o seu despertar final?",
               style: TextStyle(fontSize: 16),
             ),
@@ -304,15 +304,15 @@ class _SleepPageState extends State<SleepPage> {
   Widget _buildQuest5() {
     if (qtd > 0) {
       return Container(
-        height: 50,
+        height: 80,
         margin: EdgeInsets.symmetric(vertical: 10.0),
         child: ListView(
           scrollDirection: Axis.horizontal,
           children: [
             Container(
               alignment: Alignment.center,
-              width: 200,
-              child: Text(
+              width: MediaQuery.of(context).size.width * .50,
+              child: AutoSizeText(
                 "No total, quanto tempo durou esse despertar?",
                 style: TextStyle(fontSize: 16),
               ),
@@ -360,15 +360,15 @@ class _SleepPageState extends State<SleepPage> {
 
   Widget _buildQuest6() {
     return Container(
-      height: 50,
+      height: 80,
       margin: EdgeInsets.symmetric(vertical: 10.0),
       child: ListView(
         scrollDirection: Axis.horizontal,
         children: [
           Container(
             alignment: Alignment.center,
-            width: 200,
-            child: Text(
+            width: MediaQuery.of(context).size.width * .50,
+            child: AutoSizeText(
               "A que horas foi seu despertar final?",
               style: TextStyle(fontSize: 16),
             ),
@@ -413,15 +413,15 @@ class _SleepPageState extends State<SleepPage> {
 
   Widget _buildQuest7() {
     return Container(
-      height: 60,
+      height: 80,
       margin: EdgeInsets.symmetric(vertical: 10.0),
       child: ListView(
         scrollDirection: Axis.horizontal,
         children: [
           Container(
             alignment: Alignment.center,
-            width: 200,
-            child: Text(
+            width: MediaQuery.of(context).size.width * .50,
+            child: AutoSizeText(
               "Após seu despertar final, quanto tempo você passou na cama?",
               style: TextStyle(fontSize: 16),
             ),
@@ -466,15 +466,15 @@ class _SleepPageState extends State<SleepPage> {
 
   Widget _buildQuest8() {
     return Container(
-      height: 50,
+      height: 80,
       margin: EdgeInsets.symmetric(vertical: 10.0),
       child: ListView(
         scrollDirection: Axis.horizontal,
         children: [
           Container(
             alignment: Alignment.center,
-            width: 200,
-            child: Text(
+            width: MediaQuery.of(context).size.width * .50,
+            child: AutoSizeText(
               "Quanto você dormiu durante o dia?",
               style: TextStyle(fontSize: 16),
             ),
@@ -595,7 +595,7 @@ class _SleepPageState extends State<SleepPage> {
                                 height: MediaQuery.of(context).size.height,
                                 alignment: Alignment.center,
                                 child: Text(
-                                    "Você já respondeu o questionário hoje.\n Obrigado :3",
+                                    "Você já respondeu o questionário hoje.\n Obrigado!",
                                     textAlign: TextAlign.center,
                                     style: TextStyle(
                                       fontSize: 28,

--- a/lib/Shared/Widgets/AppDrawer.dart
+++ b/lib/Shared/Widgets/AppDrawer.dart
@@ -164,18 +164,28 @@ class _AppDrawerState extends State<AppDrawer> {
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  "Olá, $name",
-                  softWrap: false,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                      fontFamily: "Inter", fontSize: 20, color: Colors.black),
+                Container(
+                  width: MediaQuery.of(context).size.width * .50,
+                  child: FittedBox(
+                    child: Text(
+                      "Olá, $name",
+                      softWrap: false,
+                      overflow: TextOverflow.ellipsis,
+                      style:
+                          TextStyle(fontFamily: "Inter", color: Colors.black),
+                    ),
+                  ),
                 ),
                 const SizedBox(height: 4),
-                Text(
-                  email,
-                  style: TextStyle(
-                      fontFamily: "Inter", fontSize: 14, color: Colors.black),
+                Container(
+                  width: MediaQuery.of(context).size.width * .50,
+                  child: FittedBox(
+                    child: Text(
+                      email,
+                      style:
+                          TextStyle(fontFamily: "Inter", color: Colors.black),
+                    ),
+                  ),
                 ),
               ],
             )

--- a/lib/Shared/Widgets/AppDrawer.dart
+++ b/lib/Shared/Widgets/AppDrawer.dart
@@ -2,6 +2,7 @@ import 'package:app_mental/Screens/ChatPage/ChatPage.dart';
 import 'package:app_mental/Services/auth.dart';
 import 'package:app_mental/Services/database.dart';
 import 'package:app_mental/constants.dart';
+import 'package:app_mental/helper/util.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
@@ -114,6 +115,7 @@ class _AppDrawerState extends State<AppDrawer> {
         ])),
         if (user.role == types.Role.user) ...[
           Container(
+              //pode ser que seja o tamanho desse container
               child: Align(
                   alignment: FractionalOffset.bottomCenter,
                   child: Column(
@@ -165,7 +167,7 @@ class _AppDrawerState extends State<AppDrawer> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Container(
-                  width: MediaQuery.of(context).size.width * .50,
+                  width: MediaQuery.of(context).size.width * .47,
                   child: FittedBox(
                     child: Text(
                       "Olá, $name",
@@ -178,7 +180,7 @@ class _AppDrawerState extends State<AppDrawer> {
                 ),
                 const SizedBox(height: 4),
                 Container(
-                  width: MediaQuery.of(context).size.width * .50,
+                  width: MediaQuery.of(context).size.width * .47,
                   child: FittedBox(
                     child: Text(
                       email,

--- a/lib/escalas/assist/assist_result.dart
+++ b/lib/escalas/assist/assist_result.dart
@@ -241,7 +241,7 @@ class AssistResult extends StatelessWidget {
         Text(
           resultPhrase,
           style: TextStyle(
-            fontSize: 26,
+            fontSize: MediaQuery.of(context).size.height * .03,
             fontWeight: FontWeight.bold,
             color: Colors.black87,
           ),

--- a/lib/escalas/assist/assist_screen.dart
+++ b/lib/escalas/assist/assist_screen.dart
@@ -141,7 +141,7 @@ class _AssistScreenState extends State<AssistScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(titleAA!),
+        title: FittedBox(child: Text(titleAA!)),
         backgroundColor: kTextColorGreen,
       ),
       body: Padding(

--- a/lib/escalas/assistn2/assistn2_result.dart
+++ b/lib/escalas/assistn2/assistn2_result.dart
@@ -111,7 +111,7 @@ class Assistn2Result extends StatelessWidget {
         Text(
           resultPhrase,
           style: TextStyle(
-            fontSize: 26,
+            fontSize: MediaQuery.of(context).size.height * .03,
             fontWeight: FontWeight.bold,
             color: Colors.black87,
           ),

--- a/lib/escalas/assistn2/assistn2_screen.dart
+++ b/lib/escalas/assistn2/assistn2_screen.dart
@@ -88,7 +88,7 @@ class _Assistn2ScreenState extends State<Assistn2Screen> {
 
   var _questionIndex = 0;
   var _totalScoreList = List<int>.filled(11, 0);
-  var _resultOptionList = List<Object>.filled(11,0);
+  var _resultOptionList = List<Object>.filled(11, 0);
 
   void _answerQuestion(int score, Object option) {
     _totalScoreList[_questionIndex] = score;
@@ -123,10 +123,10 @@ class _Assistn2ScreenState extends State<Assistn2Screen> {
     if (_questionIndex < index) {
       _questionIndex = index;
     }
-    
+
     return Scaffold(
       appBar: AppBar(
-        title: Text(titleAA!),
+        title: FittedBox(child: Text(titleAA!)),
         backgroundColor: kTextColorGreen,
       ),
       body: Padding(

--- a/lib/escalas/mdq/mdq_result.dart
+++ b/lib/escalas/mdq/mdq_result.dart
@@ -88,7 +88,7 @@ class MdqResult extends StatelessWidget {
         Text(
           resultPhrase,
           style: TextStyle(
-            fontSize: 26,
+            fontSize: MediaQuery.of(context).size.height * .03,
             fontWeight: FontWeight.bold,
             color: Colors.black87,
           ),

--- a/lib/escalas/mdq/mdq_screen.dart
+++ b/lib/escalas/mdq/mdq_screen.dart
@@ -162,7 +162,7 @@ class _MdqScreenState extends State<MdqScreen> {
 
   var _questionIndex = 0;
   var _totalScoreList = List<int>.filled(18, 0);
-  var _resultOptionList = List<Object>.filled(18,0);
+  var _resultOptionList = List<Object>.filled(18, 0);
 
   void _answerQuestion(int score, Object option) {
     _totalScoreList[_questionIndex] = score;
@@ -201,7 +201,7 @@ class _MdqScreenState extends State<MdqScreen> {
     print("Mdq_screen: " + _userEmail!);
     return Scaffold(
       appBar: AppBar(
-        title: Text(titleAA!),
+        title: FittedBox(child: Text(titleAA!)),
         backgroundColor: kTextColorGreen,
       ),
       body: Padding(

--- a/lib/escalas/pcl5/pcl5_result.dart
+++ b/lib/escalas/pcl5/pcl5_result.dart
@@ -84,7 +84,7 @@ class Pcl5Result extends StatelessWidget {
         Text(
           resultPhrase,
           style: TextStyle(
-            fontSize: 26,
+            fontSize: MediaQuery.of(context).size.height * .03,
             fontWeight: FontWeight.bold,
             color: Colors.black87,
           ),

--- a/lib/escalas/pcl5/pcl5_screen.dart
+++ b/lib/escalas/pcl5/pcl5_screen.dart
@@ -242,7 +242,7 @@ class _Pcl5ScreenState extends State<Pcl5Screen> {
   //(p. ex. analgésicos, estimulantes, sedativos ou tranquilizantes, ou drogas como maconha, cocaína ou crack, drogas sintéticas, alucinógenos, heroína, inalantes ou solventes ou metanfetamina?
   var _questionIndex = 0;
   var _totalScoreList = List<int>.filled(21, 0);
-  var _resultOptionList = List<Object>.filled(21,0);
+  var _resultOptionList = List<Object>.filled(21, 0);
 
   void _answerQuestion(int score, int index, Object option) {
     _totalScoreList[index] = score;
@@ -272,7 +272,7 @@ class _Pcl5ScreenState extends State<Pcl5Screen> {
     }
     return Scaffold(
       appBar: AppBar(
-        title: Text(titleAA!),
+        title: FittedBox(child: Text(titleAA!)),
         backgroundColor: kTextColorGreen,
       ),
       body: Padding(

--- a/lib/escalas/phq15/phq15_result.dart
+++ b/lib/escalas/phq15/phq15_result.dart
@@ -84,7 +84,7 @@ class Phq15Result extends StatelessWidget {
         Text(
           resultPhrase,
           style: TextStyle(
-            fontSize: 26,
+            fontSize: MediaQuery.of(context).size.height * .03,
             fontWeight: FontWeight.bold,
             color: Colors.black87,
           ),

--- a/lib/escalas/phq15/phq15_screen.dart
+++ b/lib/escalas/phq15/phq15_screen.dart
@@ -186,7 +186,7 @@ class _Phq15ScreenState extends State<Phq15Screen> {
     print("phq15_screen: " + _userEmail!);
     return Scaffold(
       appBar: AppBar(
-        title: Text(titleAA!),
+        title: FittedBox(child: Text(titleAA!)),
         backgroundColor: kTextColorGreen,
       ),
       body: Padding(

--- a/lib/escalas/promisAnsiedade/promisAnsi_result.dart
+++ b/lib/escalas/promisAnsiedade/promisAnsi_result.dart
@@ -68,7 +68,7 @@ class PromisAnsiResult extends StatelessWidget {
         Text(
           resultPhrase,
           style: TextStyle(
-            fontSize: 26,
+            fontSize: MediaQuery.of(context).size.height * .03,
             fontWeight: FontWeight.bold,
             color: Colors.black87,
           ),

--- a/lib/escalas/promisAnsiedade/promisAnsi_screen.dart
+++ b/lib/escalas/promisAnsiedade/promisAnsi_screen.dart
@@ -130,7 +130,7 @@ class _PromisAnsiScreenState extends State<PromisAnsiScreen> {
     print("PromisAnsi_screen: " + _userEmail!);
     return Scaffold(
       appBar: AppBar(
-        title: Text(titleAA!),
+        title: FittedBox(child: Text(titleAA!)),
         backgroundColor: kTextColorGreen,
       ),
       body: Padding(

--- a/lib/escalas/promisn1/promisn1_result.dart
+++ b/lib/escalas/promisn1/promisn1_result.dart
@@ -21,10 +21,10 @@ class Promisn1Result extends StatelessWidget {
   final DatabaseMethods databaseMethods = new DatabaseMethods();
 
   enviarDominios(String email) async {
-    for(var i = 0; i < 10; i++){
+    for (var i = 0; i < 10; i++) {
       print(resultOptionList[i]);
     }
-    
+
     Map<String, dynamic> promisn1Map = {
       "dom1": resultScoreList[1],
       "dom2": resultScoreList[2],
@@ -202,7 +202,7 @@ class Promisn1Result extends StatelessWidget {
         Text(
           resultPhrase,
           style: TextStyle(
-            fontSize: 26,
+            fontSize: MediaQuery.of(context).size.height * .03,
             fontWeight: FontWeight.bold,
             color: Colors.black87,
           ),

--- a/lib/escalas/promisn1/promisn1_screen.dart
+++ b/lib/escalas/promisn1/promisn1_screen.dart
@@ -366,7 +366,7 @@ class _Promisn1ScreenState extends State<Promisn1Screen> {
 
   var _questionIndex = 0;
   var _totalScoreList = List<int>.filled(14, 0);
-  var _resultOptionList = List<Object>.filled(24,0);
+  var _resultOptionList = List<Object>.filled(24, 0);
 
   void _answerQuestion(int score, int domin, Object option) {
     _totalScoreList[domin] += score;
@@ -408,7 +408,7 @@ class _Promisn1ScreenState extends State<Promisn1Screen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(titleAA!),
+        title: FittedBox(child: Text(titleAA!)),
         backgroundColor: kTextColorGreen,
       ),
       body: Padding(

--- a/lib/escalas/promisn2/promisn2_result.dart
+++ b/lib/escalas/promisn2/promisn2_result.dart
@@ -72,7 +72,7 @@ class Promisn2Result extends StatelessWidget {
         Text(
           resultPhrase,
           style: TextStyle(
-            fontSize: 26,
+            fontSize: MediaQuery.of(context).size.height * .03,
             fontWeight: FontWeight.bold,
             color: Colors.black87,
           ),
@@ -88,28 +88,28 @@ class Promisn2Result extends StatelessWidget {
             onPressed: () {
               sendPromisn2Score(userEmail);
               showDialog<String>(
-                  context: context,
-                  builder: (BuildContext context) => AlertDialog(
-                    title: const Text('Entre em contato com alguém!'),
-                    content: const Text(
-                        'Percebemos que você pode estar em um estado bastante delicado e gostaríamos de sugerir que entre em contato conosco ou com alguém próximo!'),
-                    actions: <Widget>[
-                      TextButton(
-                        onPressed: () async {
-                          Navigator.pop(context, 'Ok');
-                          await Navigator.pushReplacementNamed(
-                            context,
-                            ContactsScreen.routeName,
-                            arguments: {},
-                          );
-                        },
-                        child: const Text('Ok',
-                            style: TextStyle(
-                                color: Color.fromRGBO(104, 202, 138, 1))),
-                      ),
-                    ],
-                  ),
-                );
+                context: context,
+                builder: (BuildContext context) => AlertDialog(
+                  title: const Text('Entre em contato com alguém!'),
+                  content: const Text(
+                      'Percebemos que você pode estar em um estado bastante delicado e gostaríamos de sugerir que entre em contato conosco ou com alguém próximo!'),
+                  actions: <Widget>[
+                    TextButton(
+                      onPressed: () async {
+                        Navigator.pop(context, 'Ok');
+                        await Navigator.pushReplacementNamed(
+                          context,
+                          ContactsScreen.routeName,
+                          arguments: {},
+                        );
+                      },
+                      child: const Text('Ok',
+                          style: TextStyle(
+                              color: Color.fromRGBO(104, 202, 138, 1))),
+                    ),
+                  ],
+                ),
+              );
             },
           ),
         ),

--- a/lib/escalas/promisn2/promisn2_screen.dart
+++ b/lib/escalas/promisn2/promisn2_screen.dart
@@ -115,7 +115,6 @@ class _Promisn2ScreenState extends State<Promisn2Screen> {
     setState(() {
       _questionIndex = _questionIndex + 1;
     });
-
   }
 
   void _resetQuestion() {
@@ -139,7 +138,7 @@ class _Promisn2ScreenState extends State<Promisn2Screen> {
     }
     return Scaffold(
       appBar: AppBar(
-        title: Text(titleAA!),
+        title: FittedBox(child: Text(titleAA!)),
         backgroundColor: kTextColorGreen,
       ),
       body: Padding(

--- a/lib/escalas/pset/pset_result.dart
+++ b/lib/escalas/pset/pset_result.dart
@@ -58,7 +58,7 @@ class PsetResult extends StatelessWidget {
         Text(
           resultPhrase,
           style: TextStyle(
-            fontSize: 26,
+            fontSize: MediaQuery.of(context).size.height * .03,
             fontWeight: FontWeight.bold,
             color: Colors.black87,
           ),

--- a/lib/escalas/pset/pset_screen.dart
+++ b/lib/escalas/pset/pset_screen.dart
@@ -56,7 +56,7 @@ class _PsetScreenState extends State<PsetScreen> {
     }
     return Scaffold(
       appBar: AppBar(
-        title: Text(titleAA!),
+        title: FittedBox(child: Text(titleAA!)),
         backgroundColor: kTextColorGreen,
       ),
       body: Container(

--- a/lib/escalas/psqi/psqi_result.dart
+++ b/lib/escalas/psqi/psqi_result.dart
@@ -157,7 +157,7 @@ class PsqiResult extends StatelessWidget {
         Text(
           resultPhrase,
           style: TextStyle(
-            fontSize: 26,
+            fontSize: MediaQuery.of(context).size.height * .03,
             fontWeight: FontWeight.bold,
             color: Colors.black87,
           ),

--- a/lib/escalas/psqi/psqi_screen.dart
+++ b/lib/escalas/psqi/psqi_screen.dart
@@ -322,7 +322,7 @@ class _PsqiScreenState extends State<PsqiScreen> {
     print("psqi_screen: " + _userEmail!);
     return Scaffold(
       appBar: AppBar(
-        title: Text(titleAA!),
+        title: FittedBox(child: Text(titleAA!)),
         backgroundColor: kTextColorGreen,
       ),
       body: Padding(

--- a/lib/escalas/questSD1/questSD1_result.dart
+++ b/lib/escalas/questSD1/questSD1_result.dart
@@ -63,7 +63,7 @@ class QuestSD1Result extends StatelessWidget {
         Text(
           resultPhrase,
           style: TextStyle(
-            fontSize: 26,
+            fontSize: MediaQuery.of(context).size.height * .03,
             fontWeight: FontWeight.bold,
             color: Colors.black87,
           ),

--- a/lib/escalas/questSD1/questSD1_screen.dart
+++ b/lib/escalas/questSD1/questSD1_screen.dart
@@ -125,7 +125,6 @@ class _QuestSD1ScreenState extends State<QuestSD1Screen> {
     setState(() {
       _questionIndex = _questionIndex + 1;
     });
-
   }
 
   void _resetQuestion() {
@@ -151,7 +150,7 @@ class _QuestSD1ScreenState extends State<QuestSD1Screen> {
     print("QuestSD_screen: " + _userEmail!);
     return Scaffold(
       appBar: AppBar(
-        title: Text(titleAA!),
+        title: FittedBox(child: Text(titleAA!)),
         backgroundColor: kTextColorGreen,
       ),
       body: Padding(

--- a/lib/escalas/questSD2/questSD2_result.dart
+++ b/lib/escalas/questSD2/questSD2_result.dart
@@ -73,7 +73,7 @@ class QuestSD2Result extends StatelessWidget {
         Text(
           resultPhrase,
           style: TextStyle(
-            fontSize: 26,
+            fontSize: MediaQuery.of(context).size.height * .03,
             fontWeight: FontWeight.bold,
             color: Colors.black87,
           ),

--- a/lib/escalas/questSD2/questSD2_screen.dart
+++ b/lib/escalas/questSD2/questSD2_screen.dart
@@ -168,7 +168,7 @@ class _QuestSD2ScreenState extends State<QuestSD2Screen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(titleAA!),
+        title: FittedBox(child: Text(titleAA!)),
         backgroundColor: kTextColorGreen,
       ),
       body: Padding(
@@ -182,7 +182,7 @@ class _QuestSD2ScreenState extends State<QuestSD2Screen> {
                 userEmail: _userEmail,
                 resultScoreList: _totalScoreList,
                 resultOptionList: _resultOptionList,
-                 userEscala: _userEscala!,
+                userEscala: _userEscala!,
                 questName: titleAA,
               ) //Quiz
             : QuestSD2Result(

--- a/lib/escalas/question.dart
+++ b/lib/escalas/question.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 // Cria o enunciado da questão, recebendo a penas o texto a ser mostrado.
@@ -11,10 +12,10 @@ class Question extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       margin: EdgeInsets.only(bottom: 20),
-      child: Text(
+      child: AutoSizeText(
         questionText,
         style: TextStyle(
-          fontSize: 20,
+          fontSize: MediaQuery.of(context).size.height * .018,
           color: Colors.black87,
         ),
         textAlign: TextAlign.center,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,6 +29,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.9.0"
+  auto_size_text:
+    dependency: "direct main"
+    description:
+      name: auto_size_text
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   bloc:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   intl: ^0.17.0
   url_launcher: ^6.0.12
   package_info_plus: ^1.3.0
+  auto_size_text: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Alterados textos em appbar, body, drawer, etc. para não haver quebra quando em diferentes celulares com tamanhos diferentes.
Acrescentado o pacote auto_size_text que serve para fazer com que o texto encaixe dentro de um container com o máximo de tamanho possível sendo dividido em varias linhas(fittedbox não divide em linhas).
Testar o funcionamento:
 - nos questionários.
 - no nome e email do drawer
 - no diario do sono
 - titulos nas leituras